### PR TITLE
Fix build errors, deprecation warnings for julia v0.4

### DIFF
--- a/src/JPLEphemeris.jl
+++ b/src/JPLEphemeris.jl
@@ -72,17 +72,13 @@ function position(ephem::Ephemeris, body::AbstractString, date::Float64)
     return position(c...)
 end
 
-function position(ephem::Ephemeris, body::AbstractString, date::Vector{Float64})
+function position(ephem::Ephemeris, body::AbstractString, date::AbstractVector{Float64})
     n = body == "nutations" ? 2 : 3
     p = zeros(n, length(date))
     for (i,d) in enumerate(date)
         p[:,i] = position(ephem, body, d)
     end
     return p
-end
-
-function position(ephem::Ephemeris, body::AbstractString, date::Range{Float64})
-    return position(ephem, body, [date;])
 end
 
 function velocity(ephem::Ephemeris, body::AbstractString, date::Float64)
@@ -92,17 +88,13 @@ function velocity(ephem::Ephemeris, body::AbstractString, date::Float64)
     return velocity(c...)
 end
 
-function velocity(ephem::Ephemeris, body::AbstractString, date::Vector{Float64})
+function velocity(ephem::Ephemeris, body::AbstractString, date::AbstractVector{Float64})
     n = body == "nutations" ? 2 : 3
     v = zeros(n, length(date))
     for (i,d) in enumerate(date)
         v[:,i] = velocity(ephem, body, d)
     end
     return v
-end
-
-function velocity(ephem::Ephemeris, body::AbstractString, date::Range{Float64})
-    return velocity(ephem, body, [date;])
 end
 
 function state(ephem::Ephemeris, body::AbstractString, date::Float64)
@@ -112,17 +104,13 @@ function state(ephem::Ephemeris, body::AbstractString, date::Float64)
     return [position(c...); velocity(c...)]
 end
 
-function state(ephem::Ephemeris, body::AbstractString, date::Vector{Float64})
+function state(ephem::Ephemeris, body::AbstractString, date::AbstractVector{Float64})
     n = body == "nutations" ? 4 : 6
     s = zeros(n, length(date))
     for (i,d) in enumerate(date)
         s[:,i] = state(ephem, body, d)
     end
     return s
-end
-
-function state(ephem::Ephemeris, body::AbstractString, date::Range{Float64})
-    return state(ephem, body, [date;])
 end
 
 function checkdate(ephem::Ephemeris, date::Float64)

--- a/src/JPLEphemeris.jl
+++ b/src/JPLEphemeris.jl
@@ -18,16 +18,16 @@ type Ephemeris
     finalepoch::Float64
     dtable::Vector{Vector{Float64}}
     intervall::Vector{Float64}
-    cache::Dict{String, Matrix{Float64}}
-    constants::Dict{String, Float64}
+    cache::Dict{AbstractString, Matrix{Float64}}
+    constants::Dict{AbstractString, Float64}
 
-    function Ephemeris(file::String)
+    function Ephemeris(file::AbstractString)
         fid = jldopen(file, "r")
         startepoch = read(fid, "startepoch")
         finalepoch = read(fid, "finalepoch")
         dtable = read(fid, "dtable")
         intervall = read(fid, "intervall")
-        cache = Dict{String, Matrix{Float64}}()
+        cache = Dict{AbstractString, Matrix{Float64}}()
         sizehint!(cache, mapreduce(length, +, dtable))
         constants = read(fid, "constants")
         id = constants["DENUM"]
@@ -65,14 +65,14 @@ const planets = Dict(
     "librations"=>13,
 )
 
-function position(ephem::Ephemeris, body::String, date::Float64)
+function position(ephem::Ephemeris, body::AbstractString, date::Float64)
     i = planets[body]
     checkdate(ephem, date)
     c = coefficients(ephem, i, date)
     return position(c...)
 end
 
-function position(ephem::Ephemeris, body::String, date::Vector{Float64})
+function position(ephem::Ephemeris, body::AbstractString, date::Vector{Float64})
     n = body == "nutations" ? 2 : 3
     p = zeros(n, length(date))
     for (i,d) in enumerate(date)
@@ -81,18 +81,18 @@ function position(ephem::Ephemeris, body::String, date::Vector{Float64})
     return p
 end
 
-function position(ephem::Ephemeris, body::String, date::Ranges{Float64})
+function position(ephem::Ephemeris, body::AbstractString, date::Range{Float64})
     return position(ephem, body, [date;])
 end
 
-function velocity(ephem::Ephemeris, body::String, date::Float64)
+function velocity(ephem::Ephemeris, body::AbstractString, date::Float64)
     i = planets[body]
     checkdate(ephem, date)
     c = coefficients(ephem, i, date)
     return velocity(c...)
 end
 
-function velocity(ephem::Ephemeris, body::String, date::Vector{Float64})
+function velocity(ephem::Ephemeris, body::AbstractString, date::Vector{Float64})
     n = body == "nutations" ? 2 : 3
     v = zeros(n, length(date))
     for (i,d) in enumerate(date)
@@ -101,18 +101,18 @@ function velocity(ephem::Ephemeris, body::String, date::Vector{Float64})
     return v
 end
 
-function velocity(ephem::Ephemeris, body::String, date::Ranges{Float64})
+function velocity(ephem::Ephemeris, body::AbstractString, date::Range{Float64})
     return velocity(ephem, body, [date;])
 end
 
-function state(ephem::Ephemeris, body::String, date::Float64)
+function state(ephem::Ephemeris, body::AbstractString, date::Float64)
     nbody = planets[body]
     checkdate(ephem, date)
     c = coefficients(ephem, nbody, date)
     return [position(c...); velocity(c...)]
 end
 
-function state(ephem::Ephemeris, body::String, date::Vector{Float64})
+function state(ephem::Ephemeris, body::AbstractString, date::Vector{Float64})
     n = body == "nutations" ? 4 : 6
     s = zeros(n, length(date))
     for (i,d) in enumerate(date)
@@ -121,7 +121,7 @@ function state(ephem::Ephemeris, body::String, date::Vector{Float64})
     return s
 end
 
-function state(ephem::Ephemeris, body::String, date::Ranges{Float64})
+function state(ephem::Ephemeris, body::AbstractString, date::Range{Float64})
     return state(ephem, body, [date;])
 end
 

--- a/src/JPLEphemeris.jl
+++ b/src/JPLEphemeris.jl
@@ -139,7 +139,7 @@ function coefficients(ephem::Ephemeris, nbody::Int64, date::Float64)
         d = ephem.dtable[nbody][end]
     else
         index, frac = divrem(date-ephem.startepoch, dt)
-        index = int(index) + 1
+        index = round(Int,(index) + 1)
         d = ephem.dtable[nbody][index] 
     end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -116,19 +116,19 @@ function readascii(header, datafiles, outfile)
 
     println("Parsing header file.")
     l = open(readlines, header)
-    ncoeff = int(split(l[1])[4])
+    ncoeff = parse(Int,(split(l[1])[4]))
     for i = 1:length(l)
         if startswith(l[i], "GROUP   1030")
             startepoch, finalepoch = float(split(l[i+2])[1:2])
         elseif startswith(l[i], "GROUP   1040")
-            n = int(l[i+2])
+            n = parse(Int,(l[i+2]))
             firstline = i+3
             lastline = i+3+div(n,10)
             for j = firstline:lastline
                 append!(constantnames, split(l[j]))
             end
         elseif startswith(l[i], "GROUP   1041")
-            n = int(l[i+2])
+            n = parse(Int,(l[i+2]))
             firstline = i+3
             lastline = i+3+div(n,3)
             for j = firstline:lastline
@@ -142,7 +142,7 @@ function readascii(header, datafiles, outfile)
                 # other ephemerides. The file contains no coefficients for these
                 # additional bodies though. Therefore only the first 13 indices
                 # are used.
-                ind[j-firstline+1,:] = int(split(l[j]))[1:13]
+                ind[j-firstline+1,:] = parse(Int,split(l[j])[1:13])
             end
         end
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -105,7 +105,7 @@ function readascii(header, datafiles, outfile)
     startepoch = 0.0
     finalepoch = 0.0
     ncoeff = 0
-    constantnames = String[]
+    constantnames = AbstractString[]
     constantvalues = Float64[]
     ind = zeros(Int64,3,13)
     intervall = zeros(13)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,8 +14,12 @@ function testephemeris(ephem::Ephemeris, verbose=false)
 
     for l in lines
         if ismatch(r"^[0-9]", l)
-            de, date, jd, target, center, index, value = [f(v) for (f,v) in
-            zip((string, string, float, int, int, int, float), split(l))]
+            de, date, jd, target, center, index, value = split(l)
+            jd = float(jd)
+            target = parse(Int, target)
+            center = parse(Int, center)
+            index = parse(Int, index)
+            value = float(value)
 
             if target in 14:15
                 r = state(ephem, jd, target)
@@ -49,7 +53,7 @@ function testephemeris(ephem::Ephemeris, verbose=false)
 end
 
 function state(ephem::Ephemeris, date::Float64, target::Int64)
-    s(body::String) = state(ephem, body, date)
+    s(body::AbstractString) = state(ephem, body, date)
 
     planets = Dict(1=>"mercury", 2=>"venus", 4=>"mars", 5=>"jupiter",
     6=>"saturn", 7=>"uranus", 8=>"neptune", 9=>"pluto", 11=>"sun",


### PR DESCRIPTION
Pretty basic changes - changed `Ranges{Float64}` to `Range{Float64}` (this is what was actually causing the build error, then fixed deprecation warnings (e.g. using `AbstractString` instead of `String`).